### PR TITLE
Add Abiotic Factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a collection of servers that use SteamCMD to install.
 
 [7 Days To Die](7_days_to_die)
 
+## Abiotic Factor
+
+[Abiotic Factor](abiotic_factor/)
+
 ## ARK: Survival Ascended
 
 [ARK: Survival Ascended](ark_survival_ascended)

--- a/abiotic_factor/README.md
+++ b/abiotic_factor/README.md
@@ -1,0 +1,19 @@
+# Abiotic Factor
+
+Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world’s greatest minds must survive against the universe’s biggest threats.
+
+Official server documentation: https://github.com/DFJacob/AbioticFactorDedicatedServer/wiki
+
+### Configuration files
+
+|   File    |  Purpose  |   Path  |
+|-----------|---------|---------|
+| SandboxSettings.ini | General game configuration | /home/container/AbioticFactor/Saved/SaveGames/Server/Worlds/Cascade/SandboxSettings.ini |
+| Admin.ini | Server moderator settings | /home/container/AbioticFactor/Saved/SaveGames/Server/Admin.ini |
+
+## Server Ports
+
+| Name    | Default       |
+|---------|---------------|
+| Game    | 7777 |
+| Query    | 27015   |

--- a/abiotic_factor/SandboxSettings.ini
+++ b/abiotic_factor/SandboxSettings.ini
@@ -1,0 +1,90 @@
+[SandboxSettings]
+; If true, resources will spontaneously respawn around the Facility
+LootRespawnEnabled=False
+
+; By default, power in the Facility is shut off at night, including power sockets
+PowerSocketsOffAtNight=True
+
+; This setting will allow you to disable the Day Night Cycle
+DayNightCycleState=0
+
+; Speed multiplier for the Day and Night cycle
+DayNightCycleSpeedMultiplier=1.0
+
+; In the world, sinks will passively refill over time, allowing players to drink from them
+SinkRefillRate=1.0
+
+; This value determines how fast food spoils
+FoodSpoilSpeedMultiplier=1.0
+
+; This value determines how effective it is to refrigerate items
+RefrigerationEffectivenessMultiplier=1.0
+
+; This value determines how frequently enemies respawn
+EnemySpawnRate=1.0
+
+; This is a multiplier of enemy health
+EnemyHealthMultiplier=1.0
+
+; This value will determine how damaging enemies are, as a multiplier of their damage
+EnemyPlayerDamageMultiplier=1.0
+
+; This value will determine how much damage enemies do to deployables, as a multiplier of their damage
+EnemyDeployableDamageMultiplier=1.0
+
+; This value will determine how much damage players do to other players, as a proportion of normal damage
+DamageToAlliesMultiplier=0.5
+
+; This value is a multiplier and determines how fast Hunger increases
+HungerSpeedMultiplier=1.0
+
+; This value is a multiplier and determines how fast Thirst increases
+ThirstSpeedMultiplier=1.0
+
+; This value is a multiplier and determines how fast Fatigue increases
+FatigueSpeedMultiplier=1.0
+
+; This value is a multiplier and determines how fast Continence drains
+ContinenceSpeedMultiplier=1.0
+
+; This multiplier will determine how fast enemies detect players
+DetectionSpeedMultiplier=1.0
+
+; This value is a multiplier and determines how fast XP is gained by players
+PlayerXPGainMultiplier=1.0
+
+; This is a multiplier of how many times you can stack items in an inventory slot
+ItemStackSizeMultiplier=1.0
+
+; This is a multiplier affecting how heavy items are in your inventory
+ItemWeightMultiplier=1.0
+
+; This is a multiplier for item durability
+ItemDurabilityMultiplier=1.0
+
+; This value will determine how much durability is lost on weapons and items in the player's inventory when respawning
+DurabilityLossOnDeathMultiplier=0.1
+
+; If false, players will not be notified when someone is killed by something
+ShowDeathMessages=True
+
+; If false, this will disable the ability to share item recipes with other players
+AllowRecipeSharing=True
+
+; If false, Pagers will not be useable in inventory or via the emote wheel
+AllowPagers=True
+
+; If false, players will be unable to transmogrify their armor to look like other pieces of armor using a certain piece of base equipment
+AllowTransmog=True
+
+; If true, this will remove the Research Minigames when unlocking new recipes and simply unlock the recipe right away
+DisableResearchMinigame=False
+
+; This will determine what penalties the player receives for respawning after death (or by using the Unstick option
+DeathPenalties=1
+
+; When true, all players will share the same recipe list instead of unlocking recipes individually
+GlobalRecipeUnlocks=False
+
+; When spawning into the world for the first time, this is the weapon players will receive
+FirstTimeStartingWeapon=0

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -1,0 +1,94 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2024-05-03T22:34:46-07:00",
+    "name": "Abiotic Factor",
+    "author": "git@robsti.dev",
+    "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world\u2019s greatest minds must survive against the universe\u2019s biggest threats.",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
+    },
+    "file_denylist": [],
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64 ; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=6 -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id found here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List\r\n# SRCDS_BETAID - beta branch of a steam app. Leave blank to install normal branch\r\n# SRCDS_BETAPASS - password for a beta branch should one be required during private or closed testing phases.. Leave blank for no password.\r\n# INSTALL_FLAGS - Any additional SteamCMD  flags to pass during install.. Keep in mind that steamcmd auto update process in the docker image might overwrite or ignore these when it performs update on server boot.\r\n# AUTO_UPDATE - Adding this variable to the egg allows disabling or enabling automated updates on boot. Boolean value. 0 to disable and 1 to enable.\r\n#\r\n ##\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## download the default server settings file\r\nmkdir -p \/mnt\/server\/AbioticFactor\/Saved\/SaveGames\/Server\/Worlds\/Cascade\r\ncurl -sS -o \/mnt\/server\/AbioticFactor\/Saved\/SaveGames\/Server\/Worlds\/Cascade\/SandboxSettings.ini https:\/\/raw.githubusercontent.com\/pelican-eggs\/steamcmd\/main\/abiotic_factor\/SandboxSettings.ini\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "[STEAM] SRCDS_APPID",
+            "description": "Steam App ID",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "2857200",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|numeric",
+            "field_type": "text"
+        },
+        {
+            "name": "[STEAM] Auto Update",
+            "description": "Should Auto Update",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "[SERVER] Server Name",
+            "description": "Name of the server",
+            "env_variable": "SERVER_NAME",
+            "default_value": "A Pelican Hosted Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "field_type": "text"
+        },
+        {
+            "name": "[STEAM] WINDOWS_INSTALL",
+            "description": "",
+            "env_variable": "WINDOWS_INSTALL",
+            "default_value": "1",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "[SERVER] Server Password",
+            "description": "Server access password",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:30",
+            "field_type": "text"
+        },
+        {
+            "name": "[SERVER] Query Port",
+            "description": "Steam query port",
+            "env_variable": "QUERY_PORT",
+            "default_value": "27015",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric",
+            "field_type": "text"
+        }
+    ]
+}

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-05-08T07:07:25-07:00",
+    "exported_at": "2024-05-08T16:25:28+02:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
     "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world\u2019s greatest minds must survive against the universe\u2019s biggest threats.",
@@ -15,7 +15,7 @@
         "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64 ; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log",
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-05-04T00:00:54-07:00",
+    "exported_at": "2024-05-08T07:07:25-07:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
     "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world\u2019s greatest minds must survive against the universe\u2019s biggest threats.",
@@ -86,18 +86,18 @@
             "env_variable": "QUERY_PORT",
             "default_value": "27015",
             "user_viewable": true,
-            "user_editable": true,
+            "user_editable": false,
             "rules": "required|numeric",
             "field_type": "text"
         },
         {
             "name": "[SERVER] Number of Players",
-            "description": "Numbers of allowed player connections",
+            "description": "Number of allowed player connections",
             "env_variable": "NUM_PLAYERS",
             "default_value": "6",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|numeric|min:1",
+            "rules": "required|numeric|between:1,32",
             "field_type": "text"
         }
     ]

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-05-03T22:34:46-07:00",
+    "exported_at": "2024-05-04T00:00:54-07:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
     "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world\u2019s greatest minds must survive against the universe\u2019s biggest threats.",
@@ -15,7 +15,7 @@
         "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64 ; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=6 -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log",
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64 ; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",
@@ -67,7 +67,7 @@
             "default_value": "1",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|boolean",
+            "rules": "required|boolean|in:1",
             "field_type": "text"
         },
         {
@@ -88,6 +88,16 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|numeric",
+            "field_type": "text"
+        },
+        {
+            "name": "[SERVER] Number of Players",
+            "description": "Numbers of allowed player connections",
+            "env_variable": "NUM_PLAYERS",
+            "default_value": "6",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|min:1",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description

Adds basic support for Abiotic Factor using Proton.

Also added a link to the official game server wiki in the README. It's a repository on (what appears to be) one of the developer's GitHub account, and was advertised in the official steam release announcement.

Note: that the install script downloads the sidecar INI file as the server does not create one by default (just uses the default values if the file doesn't exist). I'm adding the INI alongside such that it is pre-populated in the correct location for the end-user.

Closes https://github.com/pelican-eggs/eggs/issues/2926

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [X] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [X] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [X] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [X] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [X] The egg was exported from the panel